### PR TITLE
feat: パフォーマンス最適化と未追跡ファイルのサポート

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -14,6 +14,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getBranchHistory: (repoPath) => ipcRenderer.invoke('get-branch-history', repoPath),
   getLocalDiff: () => ipcRenderer.invoke('get-local-diff'),
   getLocalFileDiff: (filePath, isStaged) => ipcRenderer.invoke('get-local-file-diff', filePath, isStaged),
+  getUntrackedFileContent: (filePath) => ipcRenderer.invoke('get-untracked-file-content', filePath),
   
   // Event listener for CLI initialization
   onInitializeWithRepo: (callback) => ipcRenderer.on('initialize-with-repo', callback),

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -19,6 +19,7 @@ interface DiffViewerProps {
   onToggleCollapse?: () => void;
   isViewed?: boolean;
   onViewedChange?: (viewed: boolean) => void;
+  isLoading?: boolean;
 }
 
 interface DiffLine {
@@ -40,7 +41,7 @@ export interface Comment {
   fileName?: string;
 }
 
-const DiffViewer: React.FC<DiffViewerProps> = ({ diff, selectedFile, fromBranch, toBranch, isSelected = false, onRefresh, isRefreshing = false, searchTerm = '', currentSearchLineIndex = -1, currentSearchGlobalIndex = -1, onCommentsChange, isCollapsed = false, onToggleCollapse, isViewed = false, onViewedChange }) => {
+const DiffViewer: React.FC<DiffViewerProps> = ({ diff, selectedFile, fromBranch, toBranch, isSelected = false, onRefresh, isRefreshing = false, searchTerm = '', currentSearchLineIndex = -1, currentSearchGlobalIndex = -1, onCommentsChange, isCollapsed = false, onToggleCollapse, isViewed = false, onViewedChange, isLoading = false }) => {
   const diffContainerRef = useRef<HTMLDivElement>(null);
   const [copied, setCopied] = useState(false);
   const [comments, setComments] = useState<Comment[]>([]);
@@ -535,16 +536,63 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ diff, selectedFile, fromBranch,
       </div>
       
       {!isCollapsed && (
-        <div className="overflow-x-auto overflow-y-auto" ref={diffContainerRef}>
-          <div className="font-mono text-sm">
-            {parsedDiff.length > 0 ? (
-              parsedDiff.map((line, index) => renderDiffLine(line, index))
-            ) : (
-              <div className="px-4 py-8 text-center text-gray-500">
-                No changes found for this file
+        <div className="overflow-x-auto overflow-y-auto max-h-[600px]" ref={diffContainerRef}>
+          {isLoading ? (
+            <div className="p-4">
+              <div className="space-y-1 font-mono text-sm">
+                {/* Skeleton loader that mimics diff appearance */}
+                <div className="animate-pulse space-y-1">
+                  {/* Hunk header */}
+                  <div className="flex">
+                    <div className="w-16 h-4 bg-blue-100 rounded mr-2"></div>
+                    <div className="h-4 bg-blue-100 rounded w-48"></div>
+                  </div>
+                  {/* Context lines */}
+                  <div className="flex">
+                    <div className="w-16 h-4 bg-gray-100 rounded mr-2"></div>
+                    <div className="h-4 bg-gray-200 rounded w-full"></div>
+                  </div>
+                  <div className="flex">
+                    <div className="w-16 h-4 bg-gray-100 rounded mr-2"></div>
+                    <div className="h-4 bg-gray-200 rounded w-5/6"></div>
+                  </div>
+                  {/* Removed line */}
+                  <div className="flex">
+                    <div className="w-16 h-4 bg-red-100 rounded mr-2"></div>
+                    <div className="h-4 bg-red-100 rounded w-4/6"></div>
+                  </div>
+                  {/* Added lines */}
+                  <div className="flex">
+                    <div className="w-16 h-4 bg-green-100 rounded mr-2"></div>
+                    <div className="h-4 bg-green-100 rounded w-3/4"></div>
+                  </div>
+                  <div className="flex">
+                    <div className="w-16 h-4 bg-green-100 rounded mr-2"></div>
+                    <div className="h-4 bg-green-100 rounded w-5/6"></div>
+                  </div>
+                  {/* More context */}
+                  <div className="flex">
+                    <div className="w-16 h-4 bg-gray-100 rounded mr-2"></div>
+                    <div className="h-4 bg-gray-200 rounded w-4/5"></div>
+                  </div>
+                  <div className="flex">
+                    <div className="w-16 h-4 bg-gray-100 rounded mr-2"></div>
+                    <div className="h-4 bg-gray-200 rounded w-3/5"></div>
+                  </div>
+                </div>
               </div>
-            )}
-          </div>
+            </div>
+          ) : (
+            <div className="font-mono text-sm">
+              {parsedDiff.length > 0 ? (
+                parsedDiff.map((line, index) => renderDiffLine(line, index))
+              ) : (
+                <div className="px-4 py-8 text-center text-gray-500">
+                  No changes found for this file
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
       

--- a/src/components/RepositorySelector.tsx
+++ b/src/components/RepositorySelector.tsx
@@ -8,10 +8,10 @@ interface RepositorySelectorProps {
   onSelectFromHistory?: (repoPath: string) => void;
 }
 
-const RepositorySelector: React.FC<RepositorySelectorProps> = ({ 
-  onSelect, 
-  repoHistory = [], 
-  onSelectFromHistory 
+const RepositorySelector: React.FC<RepositorySelectorProps> = ({
+  onSelect,
+  repoHistory = [],
+  onSelectFromHistory
 }) => {
   const formatDate = (date: Date) => {
     return new Date(date).toLocaleDateString('ja-JP', {
@@ -32,9 +32,6 @@ const RepositorySelector: React.FC<RepositorySelectorProps> = ({
         <h2 className="text-2xl font-bold text-gray-900 mb-4">
           Select a Git Repository
         </h2>
-        <p className="text-gray-600 mb-8 max-w-md">
-          Choose a local Git repository to view diffs between branches with syntax highlighting.
-        </p>
         <button
           onClick={onSelect}
           className="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
@@ -82,4 +79,4 @@ const RepositorySelector: React.FC<RepositorySelectorProps> = ({
   );
 };
 
-export default RepositorySelector; 
+export default RepositorySelector;

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface LocalDiffData {
   stagedDiff: string;
   workingFiles: FileChange[];
   stagedFiles: FileChange[];
+  untrackedFiles: FileChange[];
   workingSummary: {
     insertions: number;
     deletions: number;
@@ -66,6 +67,7 @@ declare global {
       getBranchHistory: (repoPath: string) => Promise<BranchHistory | null>;
       getLocalDiff: () => Promise<LocalDiffData>;
       getLocalFileDiff: (filePath: string, isStaged: boolean) => Promise<{ diff: string }>;
+      getUntrackedFileContent: (filePath: string) => Promise<{ diff: string }>;
       onInitializeWithRepo: (callback: (event: any, repoPath: string) => void) => void;
       removeInitializeWithRepoListener: (callback: (event: any, repoPath: string) => void) => void;
     };


### PR DESCRIPTION
## 概要
`add-cc-view`ブランチから、Claude Code関連ではない一般的な改善点を抽出して適用しました。

## 変更内容
- 🎨 **DiffViewer**: ローディング状態のスケルトンローダーを追加
- ⚡ **LocalChangesView**: Intersection Observerによる遅延ローディングを実装
- 📁 **未追跡ファイル**: 未追跡ファイルの表示とdiff表示をサポート
- 🪟 **マルチウィンドウ**: 複数ウィンドウの適切な管理をサポート
- 🚀 **パフォーマンス**: ファイルdiffを全て一度に読み込むのではなく、オンデマンドで読み込むように最適化

## テスト内容
- [ ] DiffViewerのローディング状態が正しく表示される
- [ ] LocalChangesViewでスクロール時に自動的にファイルが読み込まれる
- [ ] 未追跡ファイルが正しく表示され、内容を確認できる
- [ ] 複数ウィンドウを開いても正常に動作する
- [ ] 大量のファイル変更がある場合でも初期表示が高速

🤖 Generated with [Claude Code](https://claude.ai/code)